### PR TITLE
Removing Usage of X from Terminology

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,8 +133,8 @@
       </p>
 
       <p>
-        In addition, this specification introduces further definitions below.
-        These terms sometimes don't use the term <em>WoT</em>. Please use the "WoT" prefix outside of the context of Web of Things.
+        In addition, this specification introduces further definitions below. These terms sometimes don't use the term
+        <em>WoT</em>. Please use the "WoT" prefix outside of the context of Web of Things.
       </p>
 
       <dl>
@@ -195,8 +195,8 @@
           <dfn id="dfn-json-schema-for-a-binding">JSON Schema for a Binding</dfn>
         </dt>
         <dd>
-          A JSON Schema that allows validating the elements added by the <a>Binding</a> (registry entry). This is
-          a supporting document for a binding entry.
+          A JSON Schema that allows validating the elements added by the <a>Binding</a> (registry entry). This is a
+          supporting document for a binding entry.
         </dd>
         <dt>
           <dfn id="dfn-json-ld-context-for-a-binding">JSON-LD Context for a Binding</dfn>
@@ -218,8 +218,8 @@
           <dfn id="dfn-vocabulary-document-for-a-binding">Vocabulary Document for a Binding</dfn>
         </dt>
         <dd>
-          A human-readable version of the vocabulary defined at <a>Vocabulary in RDF for a Binding</a>. This is a supporting
-          document for a binding entry.
+          A human-readable version of the vocabulary defined at <a>Vocabulary in RDF for a Binding</a>. This is a
+          supporting document for a binding entry.
         </dd>
         <dt>
           <dfn id="dfn-custodian">Custodian</dfn>
@@ -675,8 +675,8 @@
           <p>
             <span class="rfc2119-assertion" id="submission-requirements-summary-document"
               >The submitter MUST fill in the GitHub form provided by the custodian to generate a
-              <a href="#dfn-binding-summary">summary document</a>, which is hosted by the custodian together with
-              the registry.</span
+              <a href="#dfn-binding-summary">summary document</a>, which is hosted by the custodian together with the
+              registry.</span
             >
             This form contains the following:
           </p>


### PR DESCRIPTION
see option 4 from https://github.com/w3c/wot-binding-registry/issues/25

I added each change in a separate commit.

* WoT X Binding --> Binding
dfn-wot-x-binding --> dfn-binding

* WoT X Binding Implementation --> Binding Implementation
dfn-wot-x-binding-implementation --> dfn-binding-implementation

* WoT X Binding Summary --> Binding Summary
dfn-wot-x-binding-summary --> dfn-binding-summary

* WoT X Binding JSON Schema -> JSON Schema for a Binding
dfn-wot-x-binding-json-schema -> dfn-json-schema-for-a-binding

* WoT X Binding JSON-LD Context --> JSON-LD Context for a Binding
dfn-wot-x-binding-json-ld-context --> dfn-json-ld-context-for-a-binding

* X Vocabulary in RDF --> Vocabulary in RDF for a Binding
dfn-x-vocabulary-rdf --> dfn-vocabulary-in-rdf-for-a-binding

* X Vocabulary Document --> Vocabulary Document for a Binding
dfn-x-vocabulary-document --> dfn-vocabulary-document-for-a-binding



fixes https://github.com/w3c/wot-binding-registry/issues/25


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-bindings-registry/pull/37.html" title="Last updated on Sep 12, 2025, 8:45 AM UTC (e2cb29d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-registry/37/ad4e5bd...danielpeintner:e2cb29d.html" title="Last updated on Sep 12, 2025, 8:45 AM UTC (e2cb29d)">Diff</a>