### PR TITLE
Section ordering and titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -735,6 +735,8 @@
         <section>
           <h3>Transitions</h3>
 
+          <!-- TODO: Explain that there is no "one" submission requirement for the registry. It is about requirements for different stages -->
+
           <p>
             Every transition including the initial submission is triggered by an issue, which can be made by the
             submitter, the custodian or anyone who creates an issue using the correct template. For each transition -
@@ -790,6 +792,7 @@
           </p>
           <section id="req-traninit">
             <h3>Transition to Initial</h3>
+            <!-- TODO: Move submission requirements here. -->
             <p>
               <span class="rfc2119-assertion" id="submission-requirements-initial-submission-template"
                 >The initial submission MUST be made using
@@ -814,6 +817,7 @@
           </section>
           <section id="req-trancurr">
             <h4>Transition from <code>Initial</code> to <code>Current</code></h4>
+            <!-- TODO: link this to submission requirements. A document going for current must have everything in initial already. -->
             <ul>
               <li>
                 <span class="rfc2119-assertion" id="submission-requirements-initial-current-transition-template"
@@ -1034,41 +1038,47 @@
         <section id="req-content">
           <h3>Content</h3>
           <p>
-            <span class="rfc2119-assertion" id="submission-requirements-content-sections"
-              >The binding MUST contain the following sections in the order presented below.</span
-            >
-            <span class="rfc2119-assertion" id="submission-requirements-content-other-sections"
-              >The binding CAN contain other sections anywhere, including between the required ones.</span
-            >
-            The submitters are encouraged to look at the existing submissions.
-            <span class="rfc2119-assertion" id="submission-requirements-content-operation-mapping"
-              >There MUST be at least one operation mapped to a protocol message/vocabulary term.</span
-            >
-            <span class="rfc2119-assertion" id="submission-requirements-content-table-template"
-              >The submitter SHOULD use the table template provided in the document for the vocabulary.</span
-            >
-            <span class="rfc2119-assertion" id="submission-requirements-changelog"
-              >Each entry after the first version of the binding MUST contain a changelog in the entry itself.</span
-            >
+            Registry entries are expected to contain a human-readable document describing the binding. In order to
+            ensure a certain level of consistency and to make it easier for developers to understand how the binding
+            works and to implement it, the document is expected to contain specific sections. As protocol bindings and
+            media type bindings are expected to have different content, the requirements are different for each of them.
+            <span class="rfc2119-assertion" id="submission-requirements-content-findability">
+              While the order of the sections is not strict, the required sections MUST be present in the document with
+              the names defined in the respective types of bindings.
+            </span>
+            This allows readers to easily find the required sections. The submitters are encouraged to look at the
+            existing submissions.
           </p>
-          <ul>
-            <li>Introduction</li>
-            <li>
-              Binding Content:
-              <ul>
-                <li>URI Format</li>
-                <li>Form <a href="#dfn-vocabulary-document-for-a-binding">Vocabulary Definition as Table</a></li>
-                <li>Default and possible mappings to operations as a Table</li>
-              </ul>
-            </li>
-            <li>Examples</li>
-            <li>Changelog</li>
-          </ul>
-          <p class="note">
+          <p>
             A binding may not fit newer or older versions of a TD specification (e.g., <code>readproperty</code> can
-            become <code>readprop</code>, or a new operation can arrive). Thus, when writing a binding, it must be
-            associated with one or more known TD specification versions.
+            become <code>readprop</code>, or a new operation can arrive).
+            <span class="rfc2119-assertion" id="submission-requirements-content-td-specification-version">
+              Therefore, the binding document MUST specify the TD specification version(s) that the binding is designed
+              for and compatible with.
+            </span>
           </p>
+
+          <p>The required sections for the content of the protocol binding documents are as follows:</p>
+
+          <ul>
+            <li>URI Format</li>
+            <li>Form Vocabulary Definition</li>
+            <li>Default Mappings</li>
+            <li>Possible Mappings</li>
+            <li>Changelog of the Binding</li>
+          </ul>
+
+          <p>
+            <span class="rfc2119-assertion" id="submission-requirements-content-recommendations">
+              To help the readers, it is RECOMMENDED to include an introduction and examples of TDs with the binding.
+            </span>
+            <span class="rfc2119-assertion" id="submission-requirements-content-table-template">
+              Additionally, the submitter SHOULD use the table template provided in the document for the form vocabulary
+              definition.
+            </span>
+          </p>
+          <p>The required sections for the content of the media type binding documents are as follows:</p>
+          <p class="ednote">This will be defined separately later on.</p>
         </section>
 
         <section id="req-docs">

--- a/index.html
+++ b/index.html
@@ -735,8 +735,6 @@
         <section>
           <h3>Transitions</h3>
 
-          <!-- TODO: Explain that there is no "one" submission requirement for the registry. It is about requirements for different stages -->
-
           <p>
             Every transition including the initial submission is triggered by an issue, which can be made by the
             submitter, the custodian or anyone who creates an issue using the correct template. For each transition -
@@ -792,7 +790,6 @@
           </p>
           <section id="req-traninit">
             <h3>Transition to Initial</h3>
-            <!-- TODO: Move submission requirements here. -->
             <p>
               <span class="rfc2119-assertion" id="submission-requirements-initial-submission-template"
                 >The initial submission MUST be made using
@@ -817,7 +814,6 @@
           </section>
           <section id="req-trancurr">
             <h4>Transition from <code>Initial</code> to <code>Current</code></h4>
-            <!-- TODO: link this to submission requirements. A document going for current must have everything in initial already. -->
             <ul>
               <li>
                 <span class="rfc2119-assertion" id="submission-requirements-initial-current-transition-template"


### PR DESCRIPTION
fixes #58 

I am also adding github comments on why some sentences are removed


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-registry/pull/65.html" title="Last updated on Feb 26, 2026, 11:57 PM UTC (765e140)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-registry/65/820e75b...765e140.html" title="Last updated on Feb 26, 2026, 11:57 PM UTC (765e140)">Diff</a>