### PR TITLE
Small Error Fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -821,10 +821,16 @@
                 <span class="rfc2119-assertion" id="submission-requirements-transition-current-full-iana-registration">
                   The URI Scheme MUST be registered as a full registration at IANA for this transition.
                 </span>
-                <span class="rfc2119-assertion" id="submission-requirements-transition-iana-registration-submitter-trigger">
+                <span
+                  class="rfc2119-assertion"
+                  id="submission-requirements-transition-iana-registration-submitter-trigger"
+                >
                   The submitter SHOULD trigger the registration at IANA.
                 </span>
-                <span class="rfc2119-assertion" id="submission-requirements-transition-iana-registration-custodian-trigger">
+                <span
+                  class="rfc2119-assertion"
+                  id="submission-requirements-transition-iana-registration-custodian-trigger"
+                >
                   If needed, the custodian MAY trigger the IANA registration.
                 </span>
               </li>

--- a/index.html
+++ b/index.html
@@ -504,10 +504,6 @@
             </span>
 
             <span class="rfc2119-assertion" id="life-versioning-unique-version">
-              The content of a registry entry MAY not be updated for a given version.
-            </span>
-
-            <span class="rfc2119-assertion" id="life-versioning-unique-version">
               If anyone wants to submit a newer version of an entry, it MUST be a new submission.
             </span>
             As indicated in <a href="#transition-from-current-to-superseded">transition to superseded</a> and
@@ -822,13 +818,13 @@
                 >
               </li>
               <li>
-                <span class="rfc2119-assertion" id="submission-requirements-transition-iana-registration">
+                <span class="rfc2119-assertion" id="submission-requirements-transition-current-full-iana-registration">
                   The URI Scheme MUST be registered as a full registration at IANA for this transition.
                 </span>
-                <span class="rfc2119-assertion" id="submission-requirements-transition-iana-registration">
+                <span class="rfc2119-assertion" id="submission-requirements-transition-iana-registration-submitter-trigger">
                   The submitter SHOULD trigger the registration at IANA.
                 </span>
-                <span class="rfc2119-assertion" id="submission-requirements-transition-iana-registration">
+                <span class="rfc2119-assertion" id="submission-requirements-transition-iana-registration-custodian-trigger">
                   If needed, the custodian MAY trigger the IANA registration.
                 </span>
               </li>
@@ -1196,14 +1192,16 @@
 
       <table class="def numbered">
         <thead>
-          <th>Name</th>
-          <th>Version</th>
-          <th>Status</th>
-          <th>Binding Document Link</th>
-          <th>Ontology Prefix</th>
-          <th>Identification in TD</th>
-          <th>Supported TD version</th>
-          <th>Summary Document</th>
+          <tr>
+            <th>Name</th>
+            <th>Version</th>
+            <th>Status</th>
+            <th>Binding Document Link</th>
+            <th>Ontology Prefix</th>
+            <th>Identification in TD</th>
+            <th>Supported TD version</th>
+            <th>Summary Document</th>
+          </tr>
         </thead>
         <tbody>
           <tr>


### PR DESCRIPTION
HTML tidy showed duplicate assertion ids and then I found a leftover assertion.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-registry/pull/67.html" title="Last updated on Mar 5, 2026, 5:03 PM UTC (ea49d5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-binding-registry/67/3a852b8...ea49d5e.html" title="Last updated on Mar 5, 2026, 5:03 PM UTC (ea49d5e)">Diff</a>